### PR TITLE
TOP-16 fix the problem with a week that have joint month

### DIFF
--- a/scripts/sh/back_run.sh
+++ b/scripts/sh/back_run.sh
@@ -1,0 +1,4 @@
+cd ../../ && mvn clean install
+cd ./topchik-fetcher/target/ && java -jar topchik-fetcher-1.0-SNAPSHOT-jar-with-dependencies.jar
+cd ../../topchik-aggregator/target/ && java -jar topchik-aggregator-1.0-SNAPSHOT-jar-with-dependencies.jar
+cd ../../topchik-service && mvn exec:java

--- a/scripts/sh/front_run.sh
+++ b/scripts/sh/front_run.sh
@@ -1,0 +1,1 @@
+cd ../../topchik-static && yarn install && yarn dev

--- a/topchik-aggregator/src/main/java/ru/hh/topchik/Counter.java
+++ b/topchik-aggregator/src/main/java/ru/hh/topchik/Counter.java
@@ -17,6 +17,8 @@ import java.util.Optional;
  * */
 public class Counter {
 
+  private static final int DAYS_IN_A_WEEK = 7;
+
   private List<Action> actions = new ArrayList<>();
   private List<Achievement> achievements = new ArrayList<>();
 
@@ -57,8 +59,7 @@ public class Counter {
     for (Action action : actions) {
       Achievement achievement = new Achievement();
       achievement.setAchievementId(i++);
-      long daysToSubtract = action.getDate().getDayOfWeek().getValue() - 1;
-      achievement.setWeekDate(action.getDate().minusDays(daysToSubtract));
+      achievement.setWeekDate(getWeekEndDate(action.getDate()));
       achievement.setCategory(Category.SPRINTERS.getId());
       achievement.setPoints(action.getCounter());
       achievement.setMedal(Medal.NONE.getId());
@@ -80,5 +81,10 @@ public class Counter {
 
   public List<Achievement> getAchievements() {
     return achievements;
+  }
+
+  private LocalDate getWeekEndDate(LocalDate date) {
+    long daysToAdd = DAYS_IN_A_WEEK - date.getDayOfWeek().getValue();
+    return date.plusDays(daysToAdd);
   }
 }


### PR DESCRIPTION
В таблицу achievement (переименую в другом PR) в поле week_date заносит дату воскресенья на текущей неделе, а не понедельника.

Тикет в Trello: https://trello.com/c/Tk8yBHXf/18-top-16-back-%D1%80%D0%B5%D1%88%D0%B8%D1%82%D1%8C-%D0%BF%D1%80%D0%BE%D0%B1%D0%BB%D0%B5%D0%BC%D1%83-%D1%81-%D0%BF%D1%80-%D0%BA%D0%BE%D1%82%D0%BE%D1%80%D1%8B%D0%B5-%D0%B1%D1%8B%D0%BB%D0%B8-%D0%B7%D0%B0%D0%BC%D1%91%D1%80%D0%B4%D0%B6%D0%B5%D0%BD%D1%8B-%D0%B2-%D0%BD%D0%B0%D1%87%D0%B0%D0%BB%D0%B5-%D0%BC%D0%B5%D1%81%D1%8F%D1%86%D0%B0-%D0%B2-%D1%82%D0%BE-%D0%B2%D1%80%D0%B5%D0%BC%D1%8F-%D0%BA%D0%B0%D0%BA-%D0%BD%D0%B5%D0%B4%D0%B5%D0%BB%D1%8F-%D0%BD%D0%B0%D1%87%D0%B8%D0%BD%D0%B0%D0%BB%D0%B0%D1%81%D1%8C-%D0%B2-%D0%BF%D1%80%D0%B5%D0%B4%D1%8B%D0%B4%D1%83%D1%89%D0%B8%D0%B9-%D0%BC%D0%B5%D1%81%D1%8F%D1%86