### PR TITLE
TOP-49 fix notification bugs

### DIFF
--- a/topchik-aggregator/src/main/java/ru/hh/topchik/DbReader.java
+++ b/topchik-aggregator/src/main/java/ru/hh/topchik/DbReader.java
@@ -222,7 +222,7 @@ public class DbReader {
         } else {
           currentPointsToAdd--;
           weeklyResult.setPoints(currentPointsToAdd);
-          checkAndSendNotification(weeklyResult, referenceCommonCountPojo, currentPointsToAdd);
+          checkAndSendNotification(weeklyResult, commonCountPojos.get(i), currentPointsToAdd);
         }
 
         // Определение какую давать медаль (и давать ли)

--- a/topchik-aggregator/src/main/java/ru/hh/topchik/Notifier.java
+++ b/topchik-aggregator/src/main/java/ru/hh/topchik/Notifier.java
@@ -17,8 +17,6 @@ import java.io.InputStream;
 import java.util.Properties;
 
 public class Notifier {
-  private static final String SENDER_EMAIL = "hh.topchik@gmail.com";
-  private static final String SENDER_PASSWORD = "XXX"; // <- CHANGE THIS VALUE TO OUR PASSWORD
 
   public Notifier() {
   }
@@ -31,8 +29,8 @@ public class Notifier {
     properties.put("mail.smtp.host", "smtp.gmail.com");
     properties.put("mail.smtp.port", "587");
 
-    String senderEmail;
-    String senderPassword;
+    String senderEmail = "";
+    String senderPassword = "";
 
     try (InputStream input = getClass().getClassLoader().getResourceAsStream("sender.properties")) {
       Properties prop = new Properties();
@@ -40,8 +38,7 @@ public class Notifier {
       senderEmail = prop.getProperty("sender.email");
       senderPassword = prop.getProperty("sender.password");
     } catch (IOException e) {
-      senderEmail = SENDER_EMAIL;
-      senderPassword = SENDER_PASSWORD;
+      e.printStackTrace();
     }
 
     String finalSenderEmail = senderEmail;

--- a/topchik-model/src/main/java/dao/ReviewDaoImpl.java
+++ b/topchik-model/src/main/java/dao/ReviewDaoImpl.java
@@ -67,8 +67,7 @@ public class ReviewDaoImpl extends DaoImpl<Review> {
         "FROM Review r WHERE r.status = :status AND r.accountByAuthorId != r.pullRequestByPullRequestId.accountByAuthorId " +
         "AND r.accountByAuthorId.login NOT LIKE '%[bot]' " +
         "AND r.accountByAuthorId.login NOT LIKE 'testUser%' " +
-        "GROUP BY count_date, r.accountByAuthorId, r.pullRequestByPullRequestId.repositoryByRepoId, " +
-        "r.time, r.pullRequestByPullRequestId.creationTime " +
+        "GROUP BY count_date, r.accountByAuthorId, r.pullRequestByPullRequestId.repositoryByRepoId " +
         "ORDER BY r.pullRequestByPullRequestId.repositoryByRepoId, count_date, counter";
     return getAggregatedReviewData(dailyCommentsQuery, ReviewStatus.APPROVED);
   }
@@ -87,8 +86,7 @@ public class ReviewDaoImpl extends DaoImpl<Review> {
         "FROM Review r WHERE r.status = :status AND r.accountByAuthorId != r.pullRequestByPullRequestId.accountByAuthorId " +
         "AND r.accountByAuthorId.login NOT LIKE '%[bot]' AND date_trunc('week', r.time) != date_trunc('week', current_date()) " +
         "AND r.accountByAuthorId.login NOT LIKE 'testUser%' " +
-        "GROUP BY count_date, r.accountByAuthorId, r.pullRequestByPullRequestId.repositoryByRepoId, " +
-        "r.time, r.pullRequestByPullRequestId.creationTime " +
+        "GROUP BY count_date, r.accountByAuthorId, r.pullRequestByPullRequestId.repositoryByRepoId " +
         "ORDER BY r.pullRequestByPullRequestId.repositoryByRepoId, count_date, counter";
     return getAggregatedReviewData(weeklyCommentsQuery, ReviewStatus.APPROVED);
   }


### PR DESCRIPTION
Исправлены следующие баги:

- Пользователи, занявшие места ниже 1 получали в сообщении count такой же как у 1 места
- В категории "Добряки" пользователи могли получить несколько мест
- Дублирование senderEmail и senderPassword и в коде, и в .properties файле

[Тикет в Trello](https://trello.com/c/3OMD8i19/58-top-49-back-%D0%B8%D1%81%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D1%8F-%D0%BA%D0%BE%D1%81%D1%8F%D0%BA%D0%BE%D0%B2-%D0%BD%D0%B0-%D0%B1%D1%8D%D0%BA%D0%B5-%D0%B2%D1%81%D0%BA%D1%80%D1%8B%D0%B2%D1%88%D0%B8%D1%85%D1%81%D1%8F-%D0%BF%D0%BE%D1%81%D0%BB%D0%B5-%D0%BC%D0%B0%D1%81%D1%81%D0%BE%D0%B2%D0%BE%D0%B9-%D0%BD%D0%BE%D1%82%D0%B8%D1%84%D0%B8%D0%BA%D0%B0%D1%86%D0%B8%D0%B8)